### PR TITLE
Target macOS minimum version 10.9

### DIFF
--- a/src/webkit_server.pro
+++ b/src/webkit_server.pro
@@ -203,4 +203,6 @@ lessThan(QT_MAJOR_VERSION, 5) {
 CONFIG += console precompile_header
 CONFIG -= app_bundle
 PRECOMPILED_HEADER = stable.h
-
+macx {
+  QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
+}

--- a/test/testwebkitserver.pro
+++ b/test/testwebkitserver.pro
@@ -3,3 +3,6 @@ OBJECTS += ../src/build/IgnoreDebugOutput.o
 QT += testlib
 CONFIG += testcase console
 CONFIG -= app_bundle
+macx {
+  QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
+}


### PR DESCRIPTION
By targeting macOS 10.9 minimum, we are able to build again using Xcode
10. This avoids the use of a build configuration that was deprecated
since Xcode 8 and obsoleted in Xcode 10.

See https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes#3035632.

Fixes #1071 and #1072.